### PR TITLE
Add cross-platform build commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Perfolizer is a lightweight, JMeter-like load testing tool written in Golang. It
    go run cmd/perfolizer/main.go
    ```
 
+### Building standalone binaries (macOS + Windows)
+
+The agent (`cmd/agent`) and UI (`cmd/perfolizer`) are built separately. Below are four example cross-compile commands (macOS + Windows):
+
+```bash
+GOOS=darwin GOARCH=arm64 go build -o dist/agent-darwin-arm64 ./cmd/agent
+GOOS=darwin GOARCH=arm64 go build -o dist/perfolizer-darwin-arm64 ./cmd/perfolizer
+GOOS=windows GOARCH=amd64 go build -o dist/agent-windows-amd64.exe ./cmd/agent
+GOOS=windows GOARCH=amd64 go build -o dist/perfolizer-windows-amd64.exe ./cmd/perfolizer
+```
+
 ### Agent Configuration
 
 Default config file: `config/agent.json`


### PR DESCRIPTION
### Motivation
- Document how to produce standalone agent and UI binaries for macOS (arm64) and Windows (amd64) using Go cross-compilation flags.

### Description
- Add a new README section `Building standalone binaries (macOS + Windows)` and include four example cross-compile `go build` commands for the agent (`cmd/agent`) and UI (`cmd/perfolizer`), e.g. `GOOS=darwin GOARCH=arm64 go build -o dist/agent-darwin-arm64 ./cmd/agent` and corresponding commands for `perfolizer` and Windows targets.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a46c4698083239e2df5f15d268496)